### PR TITLE
Add health reminder script for breaks

### DIFF
--- a/reminder.sh
+++ b/reminder.sh
@@ -9,10 +9,7 @@ suggestions=(
 
 index=0
 
-<<<<<<< HEAD
-=======
 echo -e "\n✅ Health reminder script started (cycled mode). First tip in 30 minutes.\n"
->>>>>>> 580890764472ba891d9e65b43e1c2d4059359953
 # Gracefully handle script termination
 trap 'printf "\n🛑 Health reminder script exiting.\n"; exit 0' SIGINT SIGTERM
 

--- a/reminder.sh
+++ b/reminder.sh
@@ -15,10 +15,7 @@ trap 'printf "\n🛑 Health reminder script exiting.\n"; exit 0' SIGINT SIGTERM
 
 while true; do
     # … rest of your loop …
-<<<<<<< HEAD
 while true; do
-=======
->>>>>>> 580890764472ba891d9e65b43e1c2d4059359953
   sleep 1800
   tput bel
   echo -e "\n==================== HEALTH REMINDER ====================\n"

--- a/reminder.sh
+++ b/reminder.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 
+# Cycled health reminder script
 suggestions=(
-  "🧠  Look at a tree 20+ feet away for 20 seconds"
-  "🦵  Do 5 slow squats (3 sec down, 2 sec up)"
-  "🧘  Stretch your neck gently – left and right"
-  "😌  Close your eyes and relax for 30 seconds"
-  "↔️  Roll your shoulders forward and back 10 times"
+  "🧠  Look far away for 20 seconds (20-20-20)"
+  "🦵  Seated or standing leg lifts"
+  "🧘  Gentle neck rolls or head tilt"
 )
 
-echo -e "\n✅ Health reminder script started (WSL mode). You’ll get a reminder every 30 minutes.\n"
+index=0
+
+echo -e "\n✅ Health reminder script started (cycled mode). First tip in 30 minutes.\n"
 
 while true; do
   sleep 1800
-  tput bel  # This may blink or silently fail in WSL
-  echo -e "\n\033[1;33m==================== HEALTH REMINDER ====================\033[0m\n"
-  suggestion=${suggestions[$RANDOM % ${#suggestions[@]}]}
-  echo -e "$suggestion\n"
-  echo -e "\033[1;33m=========================================================\033[0m\n"
+  tput bel
+  echo -e "\n==================== HEALTH REMINDER ====================\n"
+  echo -e "${suggestions[$index]}\n"
+  echo -e "=========================================================\n"
+  index=$(( (index + 1) % ${#suggestions[@]} ))
 done

--- a/reminder.sh
+++ b/reminder.sh
@@ -9,8 +9,11 @@ suggestions=(
 
 index=0
 
-echo -e "\n✅ Health reminder script started (cycled mode). First tip in 30 minutes.\n"
+# Gracefully handle script termination
+trap 'printf "\n🛑 Health reminder script exiting.\n"; exit 0' SIGINT SIGTERM
 
+while true; do
+    # … rest of your loop …
 while true; do
   sleep 1800
   tput bel

--- a/reminder.sh
+++ b/reminder.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+suggestions=(
+  "🧠  Look at a tree 20+ feet away for 20 seconds"
+  "🦵  Do 5 slow squats (3 sec down, 2 sec up)"
+  "🧘  Stretch your neck gently – left and right"
+  "😌  Close your eyes and relax for 30 seconds"
+  "↔️  Roll your shoulders forward and back 10 times"
+)
+
+echo -e "\n✅ Health reminder script started (WSL mode). You’ll get a reminder every 30 minutes.\n"
+
+while true; do
+  sleep 1800
+  tput bel  # This may blink or silently fail in WSL
+  echo -e "\n\033[1;33m==================== HEALTH REMINDER ====================\033[0m\n"
+  suggestion=${suggestions[$RANDOM % ${#suggestions[@]}]}
+  echo -e "$suggestion\n"
+  echo -e "\033[1;33m=========================================================\033[0m\n"
+done


### PR DESCRIPTION
### **User description**
Introduce a script that provides health reminders and suggestions for breaks every 30 minutes.


___

### **PR Type**
enhancement


___

### **Description**
- Introduces a Bash script for periodic health reminders.

- Provides randomized break suggestions every 30 minutes.

- Uses terminal notifications and formatting for visibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reminder.sh</strong><dd><code>New health reminder Bash script with break suggestions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

reminder.sh

<li>Adds a new Bash script to deliver health reminders.<br> <li> Suggests randomized break activities every 30 minutes.<br> <li> Uses terminal bell and colored output for notifications.<br> <li> Designed for use in WSL environments.


</details>


  </td>
  <td><a href="https://github.com/dmitriz/health-routines/pull/2/files#diff-7a7564a6b86303ef3ffbd5f9a9626b1d2f2cffd27db7d8f2af6ef4f1671527ac">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>